### PR TITLE
JET-19015:GET /alerts/events: adding 'filter', 'filterKind' optionality

### DIFF
--- a/api-specs/api.yaml
+++ b/api-specs/api.yaml
@@ -816,6 +816,20 @@ paths:
             type: string
             format: date-time
             example: 2023-01-01T12:00:00.000Z
+        - name: filterKind
+          in: query
+          description: (optional) The kind of expression being passed in the 'filter' parameter -- these MUST appear together!
+          schema:
+            type: string
+            enum:
+              -liveunit_id
+        - name: filter
+          in: query
+          description: |-
+            (optional) A value to filter alerts by; if specified, the kind of filter must be specified in the 'filterKind' parameter
+          schema:
+            type: string
+            example: 12345678-1234-1234-1234-12345678abcd
       responses:
         200:
           description: OK


### PR DESCRIPTION
## Purpose

What is the purpose of this PR?

The LVT integration with Genetec Security Desk uses a polling-based approach to fetching alarms. Since Genetec integrations happen at the live unit level, this means Genetec installations will need the ability to query for alerts, continuously, on a polling interval.

This change involves adding the liveUnit UUID as an optional filter parameter to alerts-service's GET /alerts/events endpoint.

