### PR TITLE
jet-31414:adding distinction in get-lights endpoint; can also return 404

### DIFF
--- a/api-specs/api.yaml
+++ b/api-specs/api.yaml
@@ -294,6 +294,8 @@ paths:
           $ref: '#/components/responses/400'
         '403':
           $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
         '500':
           $ref: '#/components/responses/500'
         default:


### PR DESCRIPTION
## Purpose

### What is the purpose of this PR?

Formalize that "404 - lights not found" is a response that clients should be able to support.

### What is the associated Jira ticket?

[JET-31414](https://liveviewtech.atlassian.net/browse/JET-31414)



[JET-31414]: https://liveviewtech.atlassian.net/browse/JET-31414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ