### PR TITLE
JET-48968:fixing bad reference; 'status' -> 'state' field on update light request payload

### DIFF
--- a/api-specs/api.yaml
+++ b/api-specs/api.yaml
@@ -1463,7 +1463,7 @@ components:
           schema:
             type: object
             required:
-              - status
+              - state
             properties:
               state:
                 $ref: '#/components/schemas/lightState'


### PR DESCRIPTION
## Purpose

What is the purpose of this PR?

A field name was incorrectly specified in the updateLiveUnitLight request payload shape: `status` should instead be `state`.